### PR TITLE
Low light detection #24

### DIFF
--- a/app/src/main/java/com/sedsoftware/blinktracker/MainActivity.kt
+++ b/app/src/main/java/com/sedsoftware/blinktracker/MainActivity.kt
@@ -171,7 +171,7 @@ class MainActivity : ComponentActivity(), PictureInPictureLauncher {
             .setAspectRatio(Rational(Constants.PIP_RATIO_WIDTH, Constants.PIP_RATIO_HEIGHT))
             .apply {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    setAutoEnterEnabled(false)
+                    setAutoEnterEnabled(true)
                     setSeamlessResizeEnabled(false)
                 }
             }

--- a/app/src/main/java/com/sedsoftware/blinktracker/MainActivity.kt
+++ b/app/src/main/java/com/sedsoftware/blinktracker/MainActivity.kt
@@ -137,6 +137,10 @@ class MainActivity : ComponentActivity(), PictureInPictureLauncher {
         enterPictureInPictureMode(getPictureInPictureParams())
     }
 
+    override fun onUserLeaveHint() {
+        enterPictureInPictureMode(getPictureInPictureParams())
+    }
+
     private fun checkCameraPermissions() {
         when {
             ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED -> {

--- a/app/src/main/java/com/sedsoftware/blinktracker/MainActivity.kt
+++ b/app/src/main/java/com/sedsoftware/blinktracker/MainActivity.kt
@@ -74,7 +74,7 @@ class MainActivity : ComponentActivity(), PictureInPictureLauncher {
             .setPerformanceMode(FaceDetectorOptions.PERFORMANCE_MODE_FAST)
             .build()
 
-        _imageProcessor = FaceDetectorProcessor(faceDetectorOptions)
+        _imageProcessor = FaceDetectorProcessor(faceDetectorOptions, this)
         settings = AppSettings(applicationContext)
 
         _root = BlinkRootComponent(

--- a/app/src/main/java/com/sedsoftware/blinktracker/MainActivity.kt
+++ b/app/src/main/java/com/sedsoftware/blinktracker/MainActivity.kt
@@ -74,7 +74,7 @@ class MainActivity : ComponentActivity(), PictureInPictureLauncher {
             .setPerformanceMode(FaceDetectorOptions.PERFORMANCE_MODE_FAST)
             .build()
 
-        _imageProcessor = FaceDetectorProcessor(faceDetectorOptions, this)
+        _imageProcessor = FaceDetectorProcessor(faceDetectorOptions)
         settings = AppSettings(applicationContext)
 
         _root = BlinkRootComponent(

--- a/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
+++ b/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
@@ -34,7 +34,7 @@ interface VisionImageProcessor {
     fun stop()
 }
 
-class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions, context: Context) : VisionImageProcessor {
+class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions) : VisionImageProcessor {
     private val detector: FaceDetector = FaceDetection.getClient(detectorOptions)
     private val executor: ScopedExecutor = ScopedExecutor(TaskExecutors.MAIN_THREAD)
     private val emptyData: VisionFaceData = VisionFaceData()
@@ -43,8 +43,6 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions, context: Conte
 
     private var lastAnalyzedTimestamp = 0L
     private val lowLightThreshold = 105.0
-
-    private var myContext = context
 
     override val faceData: Flow<VisionFaceData>
         get() = _faceData
@@ -72,7 +70,6 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions, context: Conte
                 val brighterBitmap = changeBitmapContrastBrightness(originalToBitmap, 1f, luma.toFloat())
                 // Rotation degrees 0 because upright bitmap
                 inputImage = InputImage.fromBitmap(brighterBitmap, 0)
-                Toast.makeText(myContext, "Low light detected: $luma", Toast.LENGTH_SHORT).show()
             }
         }
 

--- a/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
+++ b/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
@@ -42,7 +42,7 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions, context: Conte
     private var isShutdown: Boolean = false
 
     private var lastAnalyzedTimestamp = 0L
-    private val lowLightThreshold = 90.0
+    private val lowLightThreshold = 105.0
 
     private var myContext = context
 
@@ -64,18 +64,16 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions, context: Conte
             val data = buffer.toByteArray()
             val pixels = data.map { it.toInt() and 0xFF }
             val luma = pixels.average()
-            Log.d("CameraXApp", "Average luminosity: $luma")
             lastAnalyzedTimestamp = currentTimestamp
 
             if (luma <= lowLightThreshold) {
-                Log.d("CameraXApp", "Low luminosity detected")
                 val originalToBitmap = ImageConvertUtils.getInstance().getUpRightBitmap(inputImage)
                 // Change to average luminosity
                 val brighterBitmap = changeBitmapContrastBrightness(originalToBitmap, 1f, luma.toFloat())
+//                val brighterBitmap = changeBitmapContrastBrightness(originalToBitmap, 1f, 100f)
                 // Rotation degrees 0 because upright bitmap
                 inputImage = InputImage.fromBitmap(brighterBitmap, 0)
-                Log.d("CameraXApp", "Set brightened image to detect on")
-                Toast.makeText(myContext, "Low light detected", Toast.LENGTH_SHORT).show()
+                Toast.makeText(myContext, "Low light detected: $luma", Toast.LENGTH_SHORT).show()
             }
         }
 

--- a/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
+++ b/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
@@ -70,7 +70,6 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions, context: Conte
                 val originalToBitmap = ImageConvertUtils.getInstance().getUpRightBitmap(inputImage)
                 // Change to average luminosity
                 val brighterBitmap = changeBitmapContrastBrightness(originalToBitmap, 1f, luma.toFloat())
-//                val brighterBitmap = changeBitmapContrastBrightness(originalToBitmap, 1f, 100f)
                 // Rotation degrees 0 because upright bitmap
                 inputImage = InputImage.fromBitmap(brighterBitmap, 0)
                 Toast.makeText(myContext, "Low light detected: $luma", Toast.LENGTH_SHORT).show()

--- a/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
+++ b/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
@@ -1,9 +1,16 @@
 package com.sedsoftware.blinktracker.ui.camera.core
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
+import android.util.Log
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageProxy
 import com.google.android.gms.tasks.TaskExecutors
 import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.common.internal.ImageConvertUtils
 import com.google.mlkit.vision.face.Face
 import com.google.mlkit.vision.face.FaceDetection
 import com.google.mlkit.vision.face.FaceDetector
@@ -12,7 +19,10 @@ import com.sedsoftware.blinktracker.components.tracker.model.VisionFaceData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import timber.log.Timber
+import java.nio.ByteBuffer
+import java.util.concurrent.TimeUnit
 import kotlin.math.round
+
 
 interface VisionImageProcessor {
     val faceData: Flow<VisionFaceData>
@@ -29,6 +39,9 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions) : VisionImageP
     private val _faceData: MutableStateFlow<VisionFaceData> = MutableStateFlow(emptyData)
     private var isShutdown: Boolean = false
 
+    private var lastAnalyzedTimestamp = 0L
+    private val lowLightThreshold = 90.0
+
     override val faceData: Flow<VisionFaceData>
         get() = _faceData
 
@@ -38,7 +51,30 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions) : VisionImageP
             return
         }
 
-        detector.process(InputImage.fromMediaImage(image.image!!, image.imageInfo.rotationDegrees))
+        // Get average luminosity and if light is too dim, brighten image
+        var inputImage = InputImage.fromMediaImage(image.image!!, image.imageInfo.rotationDegrees)
+        val currentTimestamp = System.currentTimeMillis()
+        if (currentTimestamp - lastAnalyzedTimestamp >=
+            TimeUnit.SECONDS.toMillis(1)) {
+            val buffer = image.planes[0].buffer
+            val data = buffer.toByteArray()
+            val pixels = data.map { it.toInt() and 0xFF }
+            val luma = pixels.average()
+            Log.d("CameraXApp", "Average luminosity: $luma")
+            lastAnalyzedTimestamp = currentTimestamp
+
+            if (luma <= lowLightThreshold) {
+                Log.d("CameraXApp", "Low luminosity detected")
+                val originalToBitmap = ImageConvertUtils.getInstance().getUpRightBitmap(inputImage)
+                // Change to average luminosity
+                val brighterBitmap = changeBitmapContrastBrightness(originalToBitmap, 1f, luma.toFloat())
+                // Rotation degrees 0 because upright bitmap
+                inputImage = InputImage.fromBitmap(brighterBitmap, 0)
+                Log.d("CameraXApp", "Set brightened image to detect on")
+            }
+        }
+
+        detector.process(inputImage)
             .addOnSuccessListener(executor) { results: List<Face> ->
                 if (results.isNotEmpty()) {
                     val face = results.first()
@@ -57,6 +93,37 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions) : VisionImageP
                 _faceData.value = emptyData
             }
             .addOnCompleteListener { image.close() }
+    }
+
+    private fun ByteBuffer.toByteArray(): ByteArray {
+        rewind()
+        val data = ByteArray(remaining())
+        get(data)
+        return data
+    }
+
+    /**
+     *
+     * @param bmp input bitmap
+     * @param contrast 0..10 1 is default
+     * @param brightness -255..255 0 is default
+     * @return new bitmap
+     */
+    private fun changeBitmapContrastBrightness(bmp: Bitmap, contrast: Float, brightness: Float): Bitmap {
+        val cm = ColorMatrix(
+            floatArrayOf(
+                contrast, 0f, 0f, 0f, brightness,
+                0f, contrast, 0f, 0f, brightness,
+                0f, 0f, contrast, 0f, brightness,
+                0f, 0f, 0f, 1f, 0f
+            )
+        )
+        val ret = Bitmap.createBitmap(bmp.width, bmp.height, bmp.config)
+        val canvas = Canvas(ret)
+        val paint = Paint()
+        paint.setColorFilter(ColorMatrixColorFilter(cm))
+        canvas.drawBitmap(bmp, 0f, 0f, paint)
+        return ret
     }
 
     override fun stop() {

--- a/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
+++ b/sources/ui/src/main/kotlin/com/sedsoftware/blinktracker/ui/camera/core/VisionImageProcessor.kt
@@ -1,11 +1,13 @@
 package com.sedsoftware.blinktracker.ui.camera.core
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.ColorMatrix
 import android.graphics.ColorMatrixColorFilter
 import android.graphics.Paint
 import android.util.Log
+import android.widget.Toast
 import androidx.camera.core.ExperimentalGetImage
 import androidx.camera.core.ImageProxy
 import com.google.android.gms.tasks.TaskExecutors
@@ -32,7 +34,7 @@ interface VisionImageProcessor {
     fun stop()
 }
 
-class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions) : VisionImageProcessor {
+class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions, context: Context) : VisionImageProcessor {
     private val detector: FaceDetector = FaceDetection.getClient(detectorOptions)
     private val executor: ScopedExecutor = ScopedExecutor(TaskExecutors.MAIN_THREAD)
     private val emptyData: VisionFaceData = VisionFaceData()
@@ -41,6 +43,8 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions) : VisionImageP
 
     private var lastAnalyzedTimestamp = 0L
     private val lowLightThreshold = 90.0
+
+    private var myContext = context
 
     override val faceData: Flow<VisionFaceData>
         get() = _faceData
@@ -71,6 +75,7 @@ class FaceDetectorProcessor(detectorOptions: FaceDetectorOptions) : VisionImageP
                 // Rotation degrees 0 because upright bitmap
                 inputImage = InputImage.fromBitmap(brighterBitmap, 0)
                 Log.d("CameraXApp", "Set brightened image to detect on")
+                Toast.makeText(myContext, "Low light detected", Toast.LENGTH_SHORT).show()
             }
         }
 


### PR DESCRIPTION
#### #24 Doesnt work in low light or in background

To count blinks in low light, we can first check if an image is too dim by comparing a threshold with the image's average luminosity. Then instead of using the camera image, make a new brightened image to send to the face detector instead.

When the app is sent to the background then picture-in-picture can be entered to do detection.